### PR TITLE
Add django-allauth for third-party authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ djangorestframework==3.15.1
 psycopg2-binary==2.9.9
 sqlparse==0.5.0
 typing_extensions==4.11.0
+django-allauth==0.36.0


### PR DESCRIPTION
This pull request includes the addition of django-allauth to the requirements.txt to support third-party authentication with Google, Apple, and Facebook.