### PR TITLE
Integrate django-allauth for enhanced authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ djangorestframework==3.15.1
 psycopg2-binary==2.9.9
 sqlparse==0.5.0
 typing_extensions==4.11.0
+
+django-allauth


### PR DESCRIPTION
This pull request includes the addition of django-allauth to the requirements.txt file, setting the stage for further integration of third-party authentication providers such as Google, Apple, and Facebook.